### PR TITLE
Fix error 401 when Address has uppercase characters

### DIFF
--- a/src/TempMail.Tests/ApiTests.cs
+++ b/src/TempMail.Tests/ApiTests.cs
@@ -189,5 +189,22 @@ namespace SmorcIRL.TempMail.Tests
         
             Assert.ThrowsAsync<HttpRequestException>(async () => await _mailClient.Login(info.Address, _password));
         }
+
+        [Test, Order(7)]
+        public async Task LoginAccountWithAddressUpperTest()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            var address = $"{_login.ToUpper()}@{await _mailClient.GetFirstAvailableDomainName()}";
+
+            Assert.ThrowsAsync<HttpRequestException>(async () => await _mailClient.Login(address, _password));
+
+            await _mailClient.Register(address, _password);
+            await _mailClient.Login(_mailClient.Email, _password);
+
+            var info = await _mailClient.GetAccountInfo();
+
+            Assert.AreEqual(address.ToLower(), info.Address);
+        }
     }
 }

--- a/src/TempMail/MailClient.API.cs
+++ b/src/TempMail/MailClient.API.cs
@@ -40,6 +40,7 @@ namespace SmorcIRL.TempMail
 
             createAccountResult.Message.EnsureSuccessStatusCode();
 
+            fullAddress = createAccountResult.Data.Address;
             var tokenResult = await _httpClient.PostAsync<GetTokenRequest, TokenInfo>(FormatUri(Endpoints.PostToken), new GetTokenRequest
             {
                 Address = fullAddress,


### PR DESCRIPTION
When you register an email has uppercase characters, the method Register will throw an error 401. I think mail.tm only uses lowercase addresses.
Please review and test it! Thanks for your lib.