### PR TITLE
Add missing models and property to `MessageDetailInfo` and `MessageInfo`, also test `MessageDetailInfo` fields in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,4 @@ _UpgradeReport_Files/
 Thumbs.db
 Desktop.ini
 .DS_Store
+*.runsettings

--- a/src/TempMail.Tests/ApiTests.cs
+++ b/src/TempMail.Tests/ApiTests.cs
@@ -113,7 +113,7 @@ namespace SmorcIRL.TempMail.Tests
             messages = await _mailClient.GetMessages(1);
             Assert.IsEmpty(messages);
 
-            const string body = "fbd49602-39ee-4fea-b555-c4796d256a2d";
+            string body = Guid.NewGuid().ToString();
             await _smtpClient.SendMailAsync(new MailMessage(_from, new MailAddress(_mailClient.Email))
             {
                 Body = body,
@@ -128,8 +128,11 @@ namespace SmorcIRL.TempMail.Tests
 
             var source = await _mailClient.GetMessageSource(message.Id);
             Assert.IsTrue(source.Data.Contains(body));
-            
+
             var messageById = await _mailClient.GetMessage(message.Id);
+
+            Assert.IsTrue(messageById.BodyText.Contains(body));
+            Assert.IsTrue(messageById.BodyHtml.First().Contains(body));
 
             Assert.AreEqual(message.Id, messageById.Id);
             Assert.AreEqual(message.MessageId, messageById.MessageId);

--- a/src/TempMail/Models/MessageDetailInfo.cs
+++ b/src/TempMail/Models/MessageDetailInfo.cs
@@ -1,24 +1,21 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace SmorcIRL.TempMail.Models
 {
     public class MessageDetailInfo : MessageInfo
     {
         [JsonProperty("cc")]
-        public string[] CC { get; set; }
+        public UserInfo[] CC { get; set; }
         
         [JsonProperty("bcc")]
-        public string[] BCC { get; set; }
+        public UserInfo[] BCC { get; set; }
         
         [JsonProperty("flagged")]
         public bool Flagged { get; set; }
         
-        // It should be string[] according to the docs, but for me, it was a single object
-        // JToken should allow any kind of JSON
         [JsonProperty("verifications")]
-        public JToken Verifications { get; set; }
+        public VerificationsInfo Verifications { get; set; }
         
         [JsonProperty("retention")]
         public bool Retention { get; set; }

--- a/src/TempMail/Models/MessageInfo.cs
+++ b/src/TempMail/Models/MessageInfo.cs
@@ -41,6 +41,9 @@ namespace SmorcIRL.TempMail.Models
         [JsonProperty("downloadUrl")] 
         public string DownloadUrl { get; set; }
 
+        [JsonProperty("sourceUrl")]
+        public string SourceUrl { get; set; }
+
         [JsonProperty("createdAt")] 
         public DateTime CreatedAt { get; set; }
 

--- a/src/TempMail/Models/TlsInfo.cs
+++ b/src/TempMail/Models/TlsInfo.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace SmorcIRL.TempMail.Models
+{
+    public class TlsInfo
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("standardName")]
+        public string StandardName { get; set; }
+
+        [JsonProperty("version")]
+        public string Version { get; set; }
+    }
+}

--- a/src/TempMail/Models/VerificationsInfo.cs
+++ b/src/TempMail/Models/VerificationsInfo.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace SmorcIRL.TempMail.Models
+{
+    public class VerificationsInfo
+    {
+        [JsonProperty("tls")]
+        public TlsInfo Tls { get; set; }
+
+        [JsonProperty("spf")]
+        public bool Spf { get; set; }
+
+        [JsonProperty("dkim")]
+        public bool Dkim { get; set; }
+    }
+}


### PR DESCRIPTION
Self explanatory title

# Changes:
- **Ignore `*.runsettings` files**: they used to provide environment variables to tests.
- **Add missing models to `MessageDetailInfo`**
- **Add missing property to `MessageInfo`**
- **Improve test suite to also test `MessageDetailInfo` fields**

# Testing
All test suites passed successfully

# References

- https://api.mail.tm/docs#/Message/api_messages_id_get

- ![image](https://github.com/user-attachments/assets/26a66fa9-2763-4c72-917e-94e43b7813e7)

- https://api.mail.tm/docs#/Message/api_messages_get_collection